### PR TITLE
fix: ensure git stats are always up-to-date in automated PR

### DIFF
--- a/.github/workflows/automated-merge.yml
+++ b/.github/workflows/automated-merge.yml
@@ -13,38 +13,43 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: develop
       
       - name: Get Git Info
         id: git-info
         run: |
-          # Ensure we have both branches
-          git fetch origin develop master
+          # Configure git to ensure we have access to all refs
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          
+          # Fetch all history and tags
+          git fetch --prune --unshallow || git fetch --prune
+          git fetch origin master:master develop:develop --force
           
           # Get number of changed files
-          echo "changes=$(git diff --name-only origin/master...origin/develop | grep -v '^$' | wc -l | xargs)" >> $GITHUB_OUTPUT
+          echo "changes=$(git diff --name-only master...develop | grep -v '^$' | wc -l | xargs)" >> $GITHUB_OUTPUT
           
           # Get additions and deletions
-          STATS=$(git diff --shortstat origin/master...origin/develop)
+          STATS=$(git diff --shortstat master...develop)
           ADDITIONS=$(echo "$STATS" | grep -o '[0-9]* insertion' | grep -o '[0-9]*' || echo "0")
           DELETIONS=$(echo "$STATS" | grep -o '[0-9]* deletion' | grep -o '[0-9]*' || echo "0")
           echo "additions=$ADDITIONS" >> $GITHUB_OUTPUT
           echo "deletions=$DELETIONS" >> $GITHUB_OUTPUT
           
           # Get contributors
-          echo "contributors=$(git log origin/master..origin/develop --format='%aN' | sort -u | paste -sd ',' -)" >> $GITHUB_OUTPUT
+          echo "contributors=$(git log master..develop --format='%aN' | sort -u | paste -sd ',' -)" >> $GITHUB_OUTPUT
           
           # Get recent changes
           echo "change_summary<<EOF" >> $GITHUB_OUTPUT
-          git log --pretty=format:'- %s (%h)' origin/master..origin/develop | head -n 5 >> $GITHUB_OUTPUT
+          git log --pretty=format:'- %s (%h)' master..develop | head -n 5 >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
           
           # Get milestones
           echo "milestones<<EOF" >> $GITHUB_OUTPUT
-          git log --grep='milestone' --pretty=format:'- %s (%h)' origin/master..origin/develop >> $GITHUB_OUTPUT
+          git log --grep='milestone' --pretty=format:'- %s (%h)' master..develop >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
           
           # Get commit count
-          echo "commit_count=$(git rev-list --count origin/master..origin/develop)" >> $GITHUB_OUTPUT
+          echo "commit_count=$(git rev-list --count master..develop)" >> $GITHUB_OUTPUT
       
       - name: Create master PR
         uses: repo-sync/pull-request@v2


### PR DESCRIPTION
## Description

This PR fixes the statistics gathering in our automated merge workflow from develop to master. The previous implementation had issues with stats not updating correctly with new commits.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Manual Testing Steps
  1. Merge a PR into develop
  2. Verify that the automated PR to master shows correct statistics
  3. Verify file changes, additions/deletions, and contributor information are accurate
  4. Verify stats update with new commits

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Additional Notes

Key improvements:
- Added ref: develop to ensure correct branch checkout
- Added git config for workspace safety
- Improved git fetch commands for complete history
- Enhanced branch synchronization
- Fixed local refs usage for better reliability
